### PR TITLE
Extend foreach when defined by Base or Compat.

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -103,6 +103,18 @@ include("collections.jl")
 # Eager
 # -----
 
+# Depending upon Julia and Compat versions, foreach may be defined as
+# a core language generic function. If so, extend rather than define
+# it.
+
+if isdefined(:foreach) && isa(foreach, Function)
+    if VERSION < v"0.5.0-dev+977"
+        import Compat.foreach
+    else
+        import Base.foreach
+    end
+end
+
 export dorun, doall, foreach
 
 @rec dorun(xs::List) = isempty(xs) ? nothing : dorun(rest(xs))


### PR DESCRIPTION
The generic function `foreach` is entering Julia Base with version 0.5 (and earlier versions via Compat).  However this function is also defined in Lazy.  This PR addresses the resulting conflict by importing `foreach` from the appropriate source so that Lazy extends `foreach` rather than defining it *ab initio*.

**Caveat** The type signature is the Lazy version of `foreach` makes this extension clear-cut  and straightforward.  However, `Base.foreach` has a different meaning as a generic function to `Lazy.foreach`.  So it may be preferable to avoid the conflict by no longer exporting `foreach` rather than extending it (as was done for other conflicting identifiers for issue #27).