### PR TITLE
Remove json macro (which can no longer work)

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -255,21 +255,6 @@ macro d(xs...)
   end
 end
 
-function prockey(key)
-  @capture(key, (a_:b_) | (a_=>b_)) || error("Invalid json key $key")
-  isa(a, Symbol) && (a = Expr(:quote, a))
-  :($a=>$b)
-end
-
-function procmap(d)
-  @capture(d, {xs__}) || return d
-  :(Dict{Any, Any}($(map(prockey, xs)...)))
-end
-
-macro json(ex)
-  @>> ex MacroTools.prewalk(procmap) esc
-end
-
 macro errs(ex)
   :(try $(esc(ex))
     catch e


### PR DESCRIPTION
Now that the deprecated syntax `{ ... }` is gone, the JSON macro can no longer work. It was unexported, undocumented, and untested, so it is fairly safe to remove.

As [far](https://github.com/search?utf8=%E2%9C%93&q=%22import+Lazy%3A+%40json%22+language%3AJulia&type=Code&ref=searchresults) as I can [tell](https://github.com/search?utf8=%E2%9C%93&q=%22import+Lazy.%40json%22+language%3AJulia&type=Code&ref=searchresults), this macro is [not used anywhere](https://github.com/search?utf8=%E2%9C%93&q=%22Lazy.%40json%22+language%3AJulia&type=Code&ref=searchresults).