### PR TITLE
Bump Lazy from 0.3 to 0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 MacroTools
-julia 0.3
+julia 0.4
 Compat 0.8.0


### PR DESCRIPTION
Use Julia 0.4 instead of 0.3. MacroTools (a dependency in the REQUIRE file) uses only v0.4 and above. 