### PR TITLE
fix StackOverflow from Listables

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -21,7 +21,7 @@ macro listable(f)
     return Expr(:block, [:(@listable $f) for f in f.args]...)
   end
   f = esc(f)
-  :($f(ls::List...) = map($f, ls...))
+  :($f(l1::List, ls::List...) = map($f, l1, ls...))
 end
 
 ########

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,4 +56,8 @@ facts("Threading macros") do
     @fact temp --> 6
 end
 
+facts("Listables") do
+    @fact_throws MethodError sin()
+end
+
 FactCheck.exitstatus()


### PR DESCRIPTION
e.g. https://github.com/JunoLab/CodeTools.jl/issues/10 by not creating methods that take no inputs