### PR TITLE
Work around removal of Base.Predicate

### DIFF
--- a/src/liblazy.jl
+++ b/src/liblazy.jl
@@ -43,7 +43,7 @@ concat(xs::List, ys::List) =
 # Manipulation
 # ------------
 
-import Base: length, map, reduce, filter, reverse, Predicate
+import Base: length, map, reduce, filter, reverse
 
 if VERSION >= v"0.6.0-dev.1015"
   import Base.Iterators: drop, take
@@ -176,6 +176,11 @@ flatten(xs::List) = reduce((xs, x) -> xs*flatten(x), list(), xs)
 # ----------
 
 import Base: any, all
+
+immutable Predicate{F}
+  f::F
+end
+(pred::Predicate)(x) = pred.f(x)::Bool
 
 ==(xs::List, ys::List) =
   isempty(xs) == isempty(ys) &&

--- a/src/liblazy.jl
+++ b/src/liblazy.jl
@@ -177,17 +177,12 @@ flatten(xs::List) = reduce((xs, x) -> xs*flatten(x), list(), xs)
 
 import Base: any, all
 
-immutable Predicate{F}
-  f::F
-end
-@compat (pred::Predicate)(x) = pred.f(x)::Bool
-
 ==(xs::List, ys::List) =
   isempty(xs) == isempty(ys) &&
     (isempty(xs) || first(xs) == first(ys) && tail(xs) == tail(ys))
 
-any(f::Predicate, xs::List) = @>> xs map(f) any
+any(f, xs::List) = @>> xs map(f) any
 @rec any(xs::List) = isempty(xs) ? false : first(xs) || any(tail(xs))
 
-all(f::Predicate, xs::List) = @>> xs map(f) all
+all(f, xs::List) = @>> xs map(f) all
 @rec all(xs::List) = isempty(xs) ? true : first(xs) && all(tail(xs))

--- a/src/liblazy.jl
+++ b/src/liblazy.jl
@@ -180,7 +180,7 @@ import Base: any, all
 immutable Predicate{F}
   f::F
 end
-(pred::Predicate)(x) = pred.f(x)::Bool
+@compat (pred::Predicate)(x) = pred.f(x)::Bool
 
 ==(xs::List, ys::List) =
   isempty(xs) == isempty(ys) &&


### PR DESCRIPTION
Fixes #57

The `Predicate` wrapper for functions was removed from Base yesterday. Since this package depends on it, the package is failing on nightly. This PR simply copies the definition that was in Base into this package. It would be great if you could tag a release after this is merged so that the packages that depend on this won't also fail.