### PR TITLE
Fix ambiguities in any/all

### DIFF
--- a/src/liblazy.jl
+++ b/src/liblazy.jl
@@ -181,8 +181,16 @@ import Base: any, all
   isempty(xs) == isempty(ys) &&
     (isempty(xs) || first(xs) == first(ys) && tail(xs) == tail(ys))
 
-any(f, xs::List) = @>> xs map(f) any
-@rec any(xs::List) = isempty(xs) ? false : first(xs) || any(tail(xs))
+if isdefined(Base, :Predicate)
+  any(f::Base.Predicate, xs::List) = @>> xs map(f) any
+  all(f::Base.Predicate, xs::List) = @>> xs map(f) all
+else
+  any(f, xs::List) = @>> xs map(f) any
+  all(f, xs::List) = @>> xs map(f) all
+end
 
-all(f, xs::List) = @>> xs map(f) all
+@rec any(xs::List) = isempty(xs) ? false : first(xs) || any(tail(xs))
+any(::typeof(@functorize(identity)), xs::List) = any(xs)
+
 @rec all(xs::List) = isempty(xs) ? true : first(xs) && all(tail(xs))
+all(::typeof(@functorize(identity)), xs::List) = all(xs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,4 +60,19 @@ facts("Listables") do
     @fact_throws MethodError sin()
 end
 
+facts("any/all") do
+    let xs = list(true, false, false)
+        @pending any(identity, xs) --> true
+        @pending any(xs) --> true
+        @pending all(identity, xs) --> false
+        @pending all(xs) --> false
+    end
+    let yy = list(1, 0, 1)
+        @pending any(Bool, yy) --> true
+        @pending all(Bool, yy) --> false
+    end
+    # Base method--ensures no ambiguity with methods here
+    @fact all([true true; true true], 1) --> [true true]
+end
+
 FactCheck.exitstatus()


### PR DESCRIPTION
Note that these annotations used to be `Base.Predicate`, but they were removed when `Predicate` was removed from Base. Their removal is causing ambiguity warnings. This PR adds an annotation of `Union{Function, DataType}`, which should fix things.

cc @tkelman, @MikeInnes 