### PR TITLE
fix `@init` macro in light of new macro scoping rules in 0.7

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -321,29 +321,23 @@ end
 
 export @init
 
-macro definit()
-  quote
-    if !isdefined(:__inits__)
-      const $(esc(:__inits__)) = Function[]
-    end
-    if !isdefined(:__init__)
-      $(esc(:__init__))() = @init
-    end
-  end
-end
-
 function initm(ex)
   quote
-    @definit
+      
+    if !isdefined(@compat(@__MODULE__), :__inits__)
+      const $(esc(:__inits__)) = Function[]
+    end
+    if !isdefined(@compat(@__MODULE__), :__init__)
+      function $(esc(:__init__))()
+        for f in $(esc(:__inits__))
+          f()
+        end
+      end
+    end
+
     push!($(esc(:__inits__)), () -> $(esc(ex)))
     nothing
   end
-end
-
-function initm()
-  :(for f in __inits__
-      f()
-    end) |> esc
 end
 
 macro init(args...)


### PR DESCRIPTION
The `@init` macro doesn't work as-is on 0.7 master because the scoping/escaping rules changed (I *think* due to https://github.com/JuliaLang/julia/pull/22985, see also https://github.com/JuliaLang/julia/issues/23221). Also, `isdefined` is deprecated. This fixes all of these things in the best (only?) way I could thing of that works on both 0.6 and 0.7 with no depwarns.