### PR TITLE
fix: colon specialized for consing a list in front of a list

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -60,6 +60,7 @@ isempty(::EmptyList) = true
 
 prepend(x, l::List) = LinkedList(x, l)
 colon(x, xs::List) = prepend(x, xs)
+colon(x::List, xs::List) = prepend(x, xs) # special case: prepend list
 colon(x,y,xs::List) = x:prepend(y,xs)
 
 list() = EmptyList()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using Base.Test
     @test tail(list(1, 2, 3)) == list(2, 3)
     @test flatten(list(1,2,list(3,4))) == list(1, 2, 3, 4)
     @test list(1,2,list(3,4))[3] == list(3, 4)
+    @test list(list(1), list(2))[1] == list(1)
 end
 
 @testset "Fibs" begin


### PR DESCRIPTION
The call `colon(list(1), list(list(2)))` is ambiguous between `colon(x, xs::Lazy.List)` from `Lazy` and `colon(x::T, y::T) where T` from `Base`.
This is fixed by adding a special case method `colon(x::Lazy.List, xs::Lazy.List)` that is otherwise identical to `colon(x, xs::Lazy.List)`.