### PR TITLE
reductions now includes the last reduction but not the initial value

### DIFF
--- a/src/liblazy.jl
+++ b/src/liblazy.jl
@@ -111,7 +111,12 @@ reduce(f::Function, xs::List) =
   isempty(xs) ? f() : reduce(f, first(xs), tail(xs))
 
 reductions(f::Function, v, xs::List) =
-  @lazy isempty(xs) ? [] : v:reductions(f, f(v, first(xs)), tail(xs))
+  @lazy if isempty(xs)
+      []
+  else
+      acc = f(v, first(xs))
+      acc:reductions(f, acc, tail(xs))
+  end
 
 reductions(f::Function, xs::List) =
   @lazy isempty(xs) ? [] : reductions(f, first(xs), tail(xs))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using Base.Test
     @test tail(list(1, 2, 3)) == list(2, 3)
     @test flatten(list(1,2,list(3,4))) == list(1, 2, 3, 4)
     @test list(1,2,list(3,4))[3] == list(3, 4)
+    @test reductions(+, 0, list(1, 2, 3)) == list(1, 3, 6)
 end
 
 @testset "Fibs" begin


### PR DESCRIPTION
`reductions(f, v, xs)` should return the final reduction value as well as all intermediate steps. Instead, it returned the initial value `v` and the intermediate reductions, but not the final one.

For example, this is the old behavior:
```julia
julia> reductions(+, 0, list(1, 2, 3))
(0 1 3)
```
while this is the correct behavior, implemented in this PR:
```julia
julia> reductions(+, 0, list(1, 2, 3))
(1 3 6)
```

The question remains whether `reductions(f, xs)` should include `first(xs)` in the result or not.
Currently, it does not include the first element.