### PR TITLE
fixed issues with threading macro for versions > 0.7

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -136,8 +136,7 @@ setindex!(xs::LinkedList, v, i::Integer) = i <= 1 ? xs.first = v : (tail(xs)[i-1
 setindex!(xs::LazyList, v, i::Integer) = i <= 1 ? realise(xs)[1] = v : (tail(xs)[i-1] = v)
 
 # Iteration over a list holds on to the head
-Base.iterate(xs::List) = xs, xs
-function Base.iterate(::List, xs::List)
+function Base.iterate(L::List, xs::List=L)
   isempty(xs) && return nothing
   first(xs), tail(xs)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ using Test
     @test list(1,2,list(3,4))[3] == list(3, 4)
     @test list(list(1), list(2))[1] == list(1)
     @test reductions(+, 0, list(1, 2, 3)) == list(1, 3, 6)
+    @test [i for i in @lazy[1,2,3]] == [1,2,3]
 end
 
 @testset "Fibs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,12 @@ using Lazy
 import Lazy: cycle, range, drop, take
 using Test
 
+# dummy macro to test threading macros on
+macro add_things(n1, n2)
+  Expr(:call, +, n1, n2)
+end
+
+
 @testset "Lazy" begin
 
 @testset "Lists" begin
@@ -48,7 +54,7 @@ end
     @test take(5, esquares) == list(4, 16, 36, 64, 100)
 end
 
-@testset "Threading macros" begin
+@testset "Threading macros" begin    
     temp = @> [2 3] sum
     @test temp == 5
     # Reverse from after index 2
@@ -59,6 +65,13 @@ end
         x + 2
     end
     @test temp == 6
+
+    # test that threading macros work with macros
+    temp = @> 2 @add_things(3)
+    @test temp == 5
+
+    temp = @>> 3 @add_things(2)
+    @test temp == 5
 end
 
 @testset "Listables" begin


### PR DESCRIPTION
- fixed issues with the threading macro `@>` when it's called on macros for Julia versions > 0.7 due to changes to macro parsing
- disabled `@_` macro for versions > 0.7