### PR TITLE
fix piping for function calls

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -98,7 +98,8 @@ macro >(exs...)
   else
 
     thread(x, ex) =
-    isexpr(ex, :call, :macrocall) ? Expr(ex.head, ex.args[1], ex.args[2], x, ex.args[3:end]...) :
+    isexpr(ex, :macrocall)        ? Expr(ex.head, ex.args[1], ex.args[2], x, ex.args[3:end]...) :
+    isexpr(ex, :call,)            ? Expr(ex.head, ex.args[1], x, ex.args[2:end]...) :
     @capture(ex, f_.(xs__))       ? :($f.($x, $(xs...))) :
     isexpr(ex, :block)            ? thread(x, rmlines(ex).args...) :
     Expr(:call, ex, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,10 @@ end
 
     temp = @>> 3 @add_things(2)
     @test temp == 5
+
+    f(x, y) = 10x+y
+    temp = @> 1 f(2)
+    @test temp == 12
 end
 
 @testset "Listables" begin


### PR DESCRIPTION
See [this comment](https://github.com/MikeInnes/Lazy.jl/issues/98#issuecomment-427946449). In Julia 1.0 due to the extra argument to macros we need a different manipulation for macros than for functions.