### PR TITLE
Fix call to macroexpand in @bounce

### DIFF
--- a/src/tail.jl
+++ b/src/tail.jl
@@ -117,7 +117,7 @@ Tail recursion that doesn't blow the stack.
 For simple cases you probably want the much faster `@rec`.
 """
 macro bounce(def)
-  def = macroexpand(def)
+  def = macroexpand(@__MODULE__, def)
   @assert isdef(def)
   @assert isexpr(def.args[1].args[1], Symbol) # TODO: handle f{T}() = ...
   f = namify(def)


### PR DESCRIPTION
There are two calls to `macroexpand` in this file, and one of them had apparently not yet been updated to use `@__MODULE__` as the first argument.