### PR TITLE
Eliminate an ambiguity in Colon

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -59,7 +59,8 @@ isempty(::EmptyList) = true
 prepend(x, l::List) = LinkedList(x, l)
 (::Colon)(x, xs::List) = prepend(x, xs)
 (::Colon)(x::List, xs::List) = prepend(x, xs) # special case: prepend list
-(::Colon)(x,y,xs::List) = x:prepend(y,xs)
+(::Colon)(x::T, y, xs::T) where T<:List = prepend(x, prepend(y, xs))
+(::Colon)(x, y, xs::List) = x:prepend(y,xs)
 
 list() = EmptyList()
 list(x, xs...) = x:list(xs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,10 @@ end
 
 @testset "Lazy" begin
 
+if VERSION >= v"1.0.0"
+    @test isempty(detect_ambiguities(Base, Core, Lazy))
+end
+
 @testset "Lists" begin
     @test list(1, 2, 3)[2] == 2
     @test prepend(1, list(2,3,4)) == 1:list(2, 3, 4)
@@ -37,6 +41,9 @@ end
     @test list(list(1), list(2))[1] == list(1)
     @test reductions(+, 0, list(1, 2, 3)) == list(1, 3, 6)
     @test [i for i in @lazy[1,2,3]] == [1,2,3]
+
+    l = list(1, 2, 3)
+    @test l:7:l == list(list(1, 2, 3), 7, 1, 2, 3)   # ambiguity test
 end
 
 @testset "Fibs" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,7 +67,7 @@ end
     @test take(5, esquares) == list(4, 16, 36, 64, 100)
 end
 
-@testset "Threading macros" begin    
+@testset "Threading macros" begin
     temp = @> [2 3] sum
     @test temp == 5
     # Reverse from after index 2
@@ -98,7 +98,7 @@ end
 
     temp = @as x 2 @m_add_things(1,x,3)
     @test temp == 123
-        
+
 end
 
 @testset "Listables" begin


### PR DESCRIPTION
Even though ambiguities are not the problem they once were (prior to https://github.com/JuliaLang/julia/pull/16125), I still tend to try to avoid them. In several of my packages, I explicitly test that I've not inadvertently introduced an ambiguity. However, when I try running those tests in Juno's console, those packages fail due to an ambiguity in Lazy.jl.

This PR fixes the ambiguity. Experts should check whether this is the *right* fix :smile:.
