### PR TITLE
Support keyword arguments in forward macro

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -282,7 +282,7 @@ macro forward(ex, fs)
   @capture(ex, T_.field_) || error("Syntax: @forward T.x f, g, h")
   T = esc(T)
   fs = isexpr(fs, :tuple) ? map(esc, fs.args) : [esc(fs)]
-  :($([:($f(x::$T, args...) = (Base.@_inline_meta; $f(x.$field, args...)))
+  :($([:($f(x::$T, args...; kwargs...) = (Base.@_inline_meta; $f(x.$field, args...; kwargs...)))
        for f in fs]...);
     nothing)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,22 @@ end
 
 end
 
+@testset "Forward macro" begin
+    struct Foo112 end
+    play(x::Foo112; y) = y                        # uses keyword arg
+    play(x::Foo112, z) = z                        # uses regular arg
+    play(x::Foo112, z1, z2; y) = y + z1 + z2      # uses both
+
+    struct Bar112 f::Foo112 end                   # composition
+    @forward Bar112.f play                        # forward `play` function to field `f`
+
+    let f = Foo112(), b = Bar112(f)
+        @test play(f, y = 1) === play(b, y = 1) 
+        @test play(f, 2) === play(b, 2) 
+        @test play(f, 2, 3, y = 1) === play(b, 2, 3, y = 1) 
+    end
+end
+
 @testset "Listables" begin
     @test_throws MethodError sin()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,11 @@ macro m_add_things(n1, n2, n3)
     end
 end
 
+# define structs for @forward macro testing below (PR #112)
+struct Foo112 end
+struct Bar112 f::Foo112 end
+    
+
 @testset "Lazy" begin
 
 if VERSION >= v"1.0.0"
@@ -100,10 +105,6 @@ end
     @test temp == 123
 
 end
-
-# define structs for @forward macro testing below
-struct Foo112 end
-struct Bar112 f::Foo112 end
 
 @testset "Forward macro" begin
     play(x::Foo112; y) = y                        # uses keyword arg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,13 +101,15 @@ end
 
 end
 
+# define structs for @forward macro testing below
+struct Foo112 end
+struct Bar112 f::Foo112 end
+
 @testset "Forward macro" begin
-    struct Foo112 end
     play(x::Foo112; y) = y                        # uses keyword arg
     play(x::Foo112, z) = z                        # uses regular arg
     play(x::Foo112, z1, z2; y) = y + z1 + z2      # uses both
 
-    struct Bar112 f::Foo112 end                   # composition
     @forward Bar112.f play                        # forward `play` function to field `f`
 
     let f = Foo112(), b = Bar112(f)


### PR DESCRIPTION
Quick test:

```
using MacroTools

macro forward(ex, fs)
    @capture(ex, T_.field_) || error("Syntax: @forward T.x f, g, h")
    T = esc(T)
    fs = isexpr(fs, :tuple) ? map(esc, fs.args) : [esc(fs)]
    :($([:($f(x::$T, args...; kwargs...) = (Base.@_inline_meta; $f(x.$field, args...; kwargs...)))
        for f in fs]...);
    nothing)
end

struct Foo1 end
play(x::Foo1; y) = y

struct Foo2 
    f::Foo1
end
@forward Foo2.f play

f1 = Foo1()
play(f1, y = 2)

f2 = Foo2(f1)
play(f2, y = 3)
```