### PR TITLE
try to avoid stackoverflow on `length`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ os:
   - linux
   - osx
 julia:
+  - 1 # current stable
   - 0.7
-  - 1.0
+  - 1.0 # lts  
   - nightly
 matrix:
   allow_failures:

--- a/src/liblazy.jl
+++ b/src/liblazy.jl
@@ -70,7 +70,15 @@ interpose(xs::List, y, n = 1) =
        take(n, xs) * (isempty(drop(n, xs)) ? [] :
                         prepend(y, interpose(drop(n, xs), y, n)))
 
-length(l::List) = isempty(l) ? 0 : 1 + length(tail(l))
+function length(l::List)
+  ret = 0
+  # unroll in while loop in order to avoid stackoverflow
+  while !isempty(l)
+    l = tail(l)
+    ret += 1
+  end
+  return ret
+end
 
 Base.lastindex(l::List) = error("Cant use `end` with List.")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,7 +124,7 @@ end
     @test_throws MethodError sin()
 end
 
-@testset "avoid stackoverflow" begin
+@static VERSION ≥ v"1.2" && @testset "avoid stackoverflow" begin
     @test (length(takewhile(<(10), Lazy.range(1))); true)
     @test (length(takewhile(<(100000), Lazy.range(1))); true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,6 +124,11 @@ end
     @test_throws MethodError sin()
 end
 
+@testset "avoid stackoverflow" begin
+    @test (length(takewhile(<(10), Lazy.range(1))); true)
+    @test (length(takewhile(<(100000), Lazy.range(1))); true)
+end
+
 @testset "any/all" begin
     let xs = list(true, false, false)
         @test any(identity, xs) == true


### PR DESCRIPTION
Long running computation is better than `StackOverFlow` ?
(well, currently stackoverflow in this `length` results in a crash, somehow)